### PR TITLE
Change 50,01% to just >50% Some text improvements too

### DIFF
--- a/50plus1.rb
+++ b/50plus1.rb
@@ -46,10 +46,10 @@ pc_hr = 40		# in hs/s
 botnum = (attck_hr / pc_hr)
 
 
-puts "Easy tool who calculates the possibility of a 50+1% attack to the Monero network".bold
+puts "A simple tool which calculates the possibility of a 50+1% attack to the Monero network".bold
 puts ""
 puts "Current global Hashrate:" + " #{toHs(network_hr).round(2)} MH/s".bold
-puts "An attacker should have an hashrate of at least:" + " #{toHs(attck_hr).round(2)} MH/s".bold
+puts "An attacker should have a hashrate of at least:" + " #{toHs(attck_hr).round(2)} MH/s".bold
 puts "or a botnet with" + " #{botnum.to_i} bots.".bold + " (calculated assuming 1 bot = 40 Hs/s)"
 
 
@@ -62,7 +62,7 @@ nanopool_perc = ((nanopool_hr/toHs(network_hr))*100).round(2)
 minergate_perc = ((minergate_hr/network_hr)*100).round(2)
 
 puts ""
-puts "List of bigger mining pools and their hashrate:".italic
+puts "List of major mining pools and their hashrate:".italic
 puts ""
 puts "Dwarfpool:".blue + "	#{dwarfpool_hr.round(2)} MH/s" + "	#{dwarfpool_perc}%".bold + " of the network"
 puts "MineXMR:".blue + "	#{minexmr_hr.round(2)} MH/s" + "	#{minexmr_perc}%".bold + " of the network"

--- a/50plus1.rb
+++ b/50plus1.rb
@@ -41,6 +41,7 @@ network_hr = network_hr_raw['hashrate']
 	
 	
 attck_hr = ((network_hr / 2) * 1.01 )
+fifty_prcnt = (network_hr / 2)
 pc_hr = 40		# in hs/s
 botnum = (attck_hr / pc_hr)
 
@@ -71,8 +72,8 @@ puts "Nanopool:".blue + "	#{nanopool_hr.round(2)} MH/s" + "	#{nanopool_perc}%".b
 puts "Minergate:".blue + "	#{toHs(minergate_hr).round(2)} MH/s" + "	#{minergate_perc}%".bold + " of the network"
 
 puts ""
-	if (dwarfpool_hr*1000000 || cryptopool_fr_hr*1000000 || minexmr_hr*1000000 || miningpoolhub_hr*1000000 || nanopool_hr*1000000 || minergate_hr)  >= attck_hr
-	puts "	DANGER: One of the mining pools has 50.01% of the network hashrate !!".red.bold
-	else puts "	None of the pools is close to the 50.01% of the global hashrate".green
+	if (dwarfpool_hr*1000000 || cryptopool_fr_hr*1000000 || minexmr_hr*1000000 || miningpoolhub_hr*1000000 || nanopool_hr*1000000 || minergate_hr)  > fifty_prcnt
+	puts "	DANGER: One of the mining pools has reached >50% of the network hashrate !!".red.bold
+	else puts "	None of these pools are close to >50% of the global hashrate".green
 	end
 

--- a/50plus1.sh
+++ b/50plus1.sh
@@ -48,10 +48,10 @@ pc_hr = 40		# in hs/s
 botnum = (attck_hr / pc_hr)
 
 
-puts "Easy tool who calculates the possibility of a 50+1% attack to the Monero network".bold
+puts "A simple tool which calculates the possibility of a 50+1% attack to the Monero network".bold
 puts ""
 puts "Current global Hashrate:" + " #{toHs(network_hr).round(2)} MH/s".bold
-puts "An attacker should have an hashrate of at least:" + " #{toHs(attck_hr).round(2)} MH/s".bold
+puts "An attacker should have a hashrate of at least:" + " #{toHs(attck_hr).round(2)} MH/s".bold
 puts "or a botnet with" + " #{botnum.to_i} bots.".bold + " (calculated assuming 1 bot = 40 Hs/s)"
 
 
@@ -64,7 +64,7 @@ nanopool_perc = ((nanopool_hr/toHs(network_hr))*100).round(2)
 minergate_perc = ((minergate_hr/network_hr)*100).round(2)
 
 puts ""
-puts "List of bigger mining pools and their hashrate:".italic
+puts "List of major mining pools and their hashrate:".italic
 puts ""
 puts "Dwarfpool:".blue + "	#{dwarfpool_hr.round(2)} MH/s" + "	#{dwarfpool_perc}%".bold + " of the network"
 puts "MineXMR:".blue + "	#{minexmr_hr.round(2)} MH/s" + "	#{minexmr_perc}%".bold + " of the network"

--- a/50plus1.sh
+++ b/50plus1.sh
@@ -9,6 +9,11 @@ class String
   include Term::ANSIColor
 end
 
+def toHs(hash)
+	hash / 1000000
+end
+
+
 	# get API of all pools
 
 string = open('http://minexmr.com/pools_hist.json')
@@ -30,34 +35,32 @@ miningpoolhub_hr = pools['miningpoolhub'].last
 nanopool_hr = pools['nanopool'].last
 minergate_hr = minergate_api["pool"]["hashrate"] 
 
-
 	# get network's Hashrate
 string = open('http://moneroblocks.info/api/get_stats/')
 read_string = string.read
 network_hr_raw = JSON.parse read_string
 network_hr = network_hr_raw['hashrate']
 	
-
+	
 attck_hr = ((network_hr / 2) * 1.01 )
+fifty_prcnt = (network_hr / 2)
 pc_hr = 40		# in hs/s
 botnum = (attck_hr / pc_hr)
 
 
-
 puts "Easy tool who calculates the possibility of a 50+1% attack to the Monero network".bold
 puts ""
-puts "Current global Hashrate:" + " #{(network_hr/1000000).round(2)} MH/s".bold
-puts "An attacker should have an hashrate of at least:" + " #{(attck_hr/1000000).round(2)} MH/s".bold
+puts "Current global Hashrate:" + " #{toHs(network_hr).round(2)} MH/s".bold
+puts "An attacker should have an hashrate of at least:" + " #{toHs(attck_hr).round(2)} MH/s".bold
 puts "or a botnet with" + " #{botnum.to_i} bots.".bold + " (calculated assuming 1 bot = 40 Hs/s)"
 
 
-
 	#calculate percentage network
-dwarfpool_perc = ((dwarfpool_hr/(network_hr/1000000))*100).round(2)
-cryptopool_fr_perc = ((cryptopool_fr_hr/(network_hr/1000000))*100).round(2)
-minexmr_perc = ((minexmr_hr/(network_hr/1000000))*100).round(2)
-miningpoolhub_perc = ((miningpoolhub_hr/(network_hr/1000000))*100).round(2)
-nanopool_perc = ((nanopool_hr/(network_hr/1000000))*100).round(2)
+dwarfpool_perc = ((dwarfpool_hr/toHs(network_hr))*100).round(2)
+cryptopool_fr_perc = ((cryptopool_fr_hr/toHs(network_hr))*100).round(2)
+minexmr_perc = ((minexmr_hr/toHs(network_hr))*100).round(2)
+miningpoolhub_perc = ((miningpoolhub_hr/toHs(network_hr))*100).round(2)
+nanopool_perc = ((nanopool_hr/toHs(network_hr))*100).round(2)
 minergate_perc = ((minergate_hr/network_hr)*100).round(2)
 
 puts ""
@@ -68,11 +71,11 @@ puts "MineXMR:".blue + "	#{minexmr_hr.round(2)} MH/s" + "	#{minexmr_perc}%".bold
 puts "Cryptopool:".blue + "	#{cryptopool_fr_hr.round(2)} MH/s" + "	#{cryptopool_fr_perc}%".bold + " of the network"
 puts "Miningpool Hub:".blue + "	#{miningpoolhub_hr.round(2)} MH/s" + "	#{miningpoolhub_perc}%".bold + " of the network"
 puts "Nanopool:".blue + "	#{nanopool_hr.round(2)} MH/s" + "	#{nanopool_perc}%".bold + " of the network"
-puts "Minergate:".blue + "	#{minergate_hr.round(2)/ 1000000} MH/s" + "	#{minergate_perc}%".bold + " of the network"
+puts "Minergate:".blue + "	#{toHs(minergate_hr).round(2)} MH/s" + "	#{minergate_perc}%".bold + " of the network"
 
 puts ""
-	if (dwarfpool_hr*1000000 || cryptopool_fr_hr*1000000 || minexmr_hr*1000000 || miningpoolhub_hr*1000000 || nanopool_hr*1000000 || minergate_hr)  >= attck_hr
-	puts "	DANGER: One of the mining pools has 50.01% of the network hashrate !!".red.bold
-	else puts "	None of the pools is close to the 50.01% of the global hashrate".green
+	if (dwarfpool_hr*1000000 || cryptopool_fr_hr*1000000 || minexmr_hr*1000000 || miningpoolhub_hr*1000000 || nanopool_hr*1000000 || minergate_hr)  > fifty_prcnt
+	puts "	DANGER: One of the mining pools has reached >50% of the network hashrate !!".red.bold
+	else puts "	None of these pools are close to >50% of the global hashrate".green
 	end
 


### PR DESCRIPTION
In theory, a 50% +1 attack only requires 50% plus a *tiny* fraction of a percent to do its malicous "things". Because of this, this PR makes it so that the warning message will show up if a pool reaches *any* greater than 50% rather than having to hit 50,01% first. Some text improvements too.